### PR TITLE
fix: loading bar restarting

### DIFF
--- a/html/app.js
+++ b/html/app.js
@@ -97,28 +97,9 @@ function videotoggle() {
     }
 }
 
-let count = 0;
-let thisCount = 0;
-
 const handlers = {
-    startInitFunctionOrder(data) {
-        count = data.count;
-    },
-
-    initFunctionInvoking(data) {
-        document.querySelector(".thingy").style.left = "0%";
-        document.querySelector(".thingy").style.width = (data.idx / count) * 100 + "%";
-    },
-
-    startDataFileEntries(data) {
-        count = data.count;
-    },
-
-    performMapLoadFunction(data) {
-        ++thisCount;
-
-        document.querySelector(".thingy").style.left = "0%";
-        document.querySelector(".thingy").style.width = (thisCount / count) * 100 + "%";
+    loadProgress({ loadFraction }) {
+        document.querySelector(".thingy").style.width = loadFraction * 100 + "%";
     },
 };
 


### PR DESCRIPTION
## Description

Makes the loading bar not restart multiple times.

Inspired by [this comment](https://github.com/citizenfx/cfx-server-data/blob/master/resources/%5Btest%5D/example-loadscreen/index.html#L25C1-L25C123) in cfx's `example-loadscreen`.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
