### PR TITLE
fix: seamless transition

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1,8 +1,0 @@
-local checkState = false
-
-AddEventHandler("playerSpawned", function ()
-    if not checkState then
-        ShutdownLoadingScreenNui()
-        checkState = true
-    end
-end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,11 +1,10 @@
 fx_version 'cerulean'
 game 'gta5'
 
-description 'QBX_Loading'
+name 'qbx_loading'
+description 'Loading screen for Qbox'
 repository 'https://github.com/Qbox-project/qbx_loading'
-version '1.0'
-
-client_script 'client/client.lua'
+version '1.0.0'
 
 files {
     'html/assets/**',
@@ -15,6 +14,7 @@ files {
 loadscreen {
     'html/index.html'
 }
+
 loadscreen_cursor 'yes'
 loadscreen_manual_shutdown 'yes'
 


### PR DESCRIPTION
## Description

This removed the unnecessary `ShutdownLoadingScreenNui()` which shuts down the loading screen before everything has a chance to load leading to a not so seamless transition from loading screen to character selection

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
